### PR TITLE
chore: migrate renovate preset to tasshi-me/configs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>cybozu/renovate-config"]
+  "extends": ["github>tasshi-me/configs"]
 }


### PR DESCRIPTION
Switch the Renovate preset from `cybozu/renovate-config` to [`tasshi-me/configs`](https://github.com/tasshi-me/configs) to keep personal repositories on the personal preset.